### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ snips edit python-test-class
 
 snips remove python-test-class
 ```
-    
+
 Every snippets is stored in your home directory in .snips.
 You can store this directory in git.
 

--- a/snips/snip_complete.sh
+++ b/snips/snip_complete.sh
@@ -1,5 +1,5 @@
 #/bin/bash -x
- 
+
 function _snip_complete_()
 {
     local cmd="${1##*/}"
@@ -9,5 +9,5 @@ function _snip_complete_()
 
     COMPREPLY=( $(compgen -W "$(snips list)" -- "${word}" ))
 }
- 
+
 complete -F _snip_complete_ snip


### PR DESCRIPTION
This pull requests removes trailing whitespaces from both the `README` and the `snip_complete.sh` files.